### PR TITLE
Add Edit Post Feature with Feature Testing

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -49,10 +49,27 @@ class PostController extends Controller
 
     public function edit(Post $post)
     {
+        $categories = Category::all();
+        return view('posts.edit', compact('post', 'categories'));
     }
 
     public function update(Request $request, Post $post)
     {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required|string',
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $post->update([
+            'title' => $request->get('title'),
+            'content' => $request->get('content'),
+            'slug' => Str::slug($request->get('title')),
+            'status' => $request->input('status', 0),
+            'category_id' => $request->category_id,
+        ]);
+
+        return redirect()->route('posts.index')->with('success', 'Post updated successfully.');
     }
 
     public function destroy(Post $post)

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,57 @@
+<!-- resources/views/posts/edit.blade.php -->
+
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Edit Post') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    @if ($errors->any())
+                        <div class="mb-4">
+                            <ul class="list-disc list-inside text-red-500">
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form action="{{ route('posts.update', $post) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+
+                        <div class="mb-4">
+                            <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+                            <input type="text" name="title" id="title" value="{{ old('title', $post->title) }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="content" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Content</label>
+                            <textarea name="content" id="content" rows="5" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">{{ old('content', $post->content) }}</textarea>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="category_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Category</label>
+                            <select name="category_id" id="category_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                                <option value="">Select a category</option>
+                                @foreach ($categories as $category)
+                                    <option value="{{ $category->id }}" {{ old('category_id', $post->category_id) == $category->id ? 'selected' : '' }}>{{ $category->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="flex items-center justify-end mt-4">
+                            <button type="submit" name="status" value="0" class="bg-gray-500 text-white py-2 px-4 rounded mr-2">Save as Draft</button>
+                            <button type="submit" name="status" value="1" class="bg-blue-500 text-white py-2 px-4 rounded">Publish Post</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/tests/Feature/Post/PostEditTest.php
+++ b/tests/Feature/Post/PostEditTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Post;
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->category = Category::factory()->create();
+    $this->post = Post::factory()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $this->category->id,
+    ]);
+});
+
+it('can display the edit post page', function () {
+    $this->get(route('posts.edit', $this->post))
+        ->assertStatus(200)
+        ->assertSee('Edit Post')
+        ->assertSee($this->post->title)
+        ->assertSee($this->category->name);
+});
+
+it('can update a post and save as draft', function () {
+    $updatedData = [
+        'title' => 'Updated Post Title',
+        'content' => 'This is the updated content of the post.',
+        'category_id' => $this->category->id,
+        'status' => 0, // Save as draft
+    ];
+
+    $this->put(route('posts.update', $this->post), $updatedData)
+        ->assertRedirect(route('posts.index'))
+        ->assertSessionHas('success', 'Post updated successfully.');
+
+    $this->assertDatabaseHas('posts', [
+        'id' => $this->post->id,
+        'title' => 'Updated Post Title',
+        'status' => 0,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+it('can update a post and publish it', function () {
+    $updatedData = [
+        'title' => 'Published Post Title',
+        'content' => 'This is the published content of the post.',
+        'category_id' => $this->category->id,
+        'status' => 1, // Publish post
+    ];
+
+    $this->put(route('posts.update', $this->post), $updatedData)
+        ->assertRedirect(route('posts.index'))
+        ->assertSessionHas('success', 'Post updated successfully.');
+
+    $this->assertDatabaseHas('posts', [
+        'id' => $this->post->id,
+        'title' => 'Published Post Title',
+        'status' => 1,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+it('validates required fields when updating a post', function () {
+    $this->put(route('posts.update', $this->post), [])
+        ->assertSessionHasErrors(['title', 'content', 'category_id']);
+});


### PR DESCRIPTION
This Pull Request introduces the following:

### Features Added:
- **Edit Post Page**: Implemented the `edit()` method in `PostController` to display a form for editing an existing post.
- **Update Post Functionality**: Implemented the `update()` method to handle form submission and update the post data, including title, content, status, and category.
- **Draft and Publish Options**: Added buttons for saving posts as draft or publishing them directly when editing a post.

### Tests Added:
- **Edit Post Page Test**: Added tests to verify that the edit post page can be accessed successfully and displays the correct information.
- **Update Post Tests**: Added tests for both saving a post as a draft and publishing it.
- **Validation Test**: Added tests to ensure that all required fields are validated properly when updating a post.

This PR closes issues:
- [#7](https://github.com/qadrtech-ai/simple-blog/issues/7): Implement edit post feature

close #7 

Please review the changes and suggest if any further improvements are needed.
