### PR TITLE
Add Category Deletion Feature Tests with Validation Scenarios

### DIFF
--- a/tests/Feature/Category/CategoryCreateTest.php
+++ b/tests/Feature/Category/CategoryCreateTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(); // Assuming you have a seed that creates necessary data like users or categories
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('can create a new category', function () {
+    $categoryData = [
+        'name' => 'New Category',
+        'parent_id' => null,
+    ];
+
+    $this->post(route('categories.store'), $categoryData)
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('success', 'Category created successfully.');
+
+    $this->assertDatabaseHas('categories', [
+        'name' => 'New Category',
+    ]);
+});
+
+it('validates category creation fields', function () {
+    $this->post(route('categories.store'), [])
+        ->assertSessionHasErrors(['name']);
+});
+
+it('can create a category with a parent', function () {
+    $parentCategory = Category::factory()->create(['name' => 'Parent Category']);
+
+    $categoryData = [
+        'name' => 'Child Category',
+        'parent_id' => $parentCategory->id,
+    ];
+
+    $this->post(route('categories.store'), $categoryData)
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('success', 'Category created successfully.');
+
+    $this->assertDatabaseHas('categories', [
+        'name' => 'Child Category',
+        'parent_id' => $parentCategory->id,
+    ]);
+});

--- a/tests/Feature/Category/CategoryDeleteTest.php
+++ b/tests/Feature/Category/CategoryDeleteTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(); // Assuming you have a seed that creates necessary data like users or categories
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('can delete a category that is not associated with any posts', function () {
+    $category = Category::factory()->create(['name' => 'Category to Delete']);
+
+    $this->delete(route('categories.destroy', $category))
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('success', 'Category deleted successfully.');
+
+    $this->assertDatabaseMissing('categories', [
+        'id' => $category->id,
+    ]);
+});
+
+it('cannot delete a category that is associated with posts', function () {
+    $category = Category::factory()->create(['name' => 'Category with Posts']);
+    Post::factory()->create(['category_id' => $category->id]);
+
+    $this->delete(route('categories.destroy', $category))
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('error', 'Category cannot be deleted because it is associated with existing posts.');
+
+    $this->assertDatabaseHas('categories', [
+        'id' => $category->id,
+    ]);
+});

--- a/tests/Feature/Category/CategoryEditTest.php
+++ b/tests/Feature/Category/CategoryEditTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(); // Assuming you have a seed that creates necessary data like users or categories
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('can update an existing category', function () {
+    $category = Category::factory()->create(['name' => 'Old Category Name']);
+
+    $updatedData = [
+        'name' => 'Updated Category Name',
+        'parent_id' => null,
+    ];
+
+    $this->put(route('categories.update', $category), $updatedData)
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('success', 'Category updated successfully.');
+
+    $this->assertDatabaseHas('categories', [
+        'id' => $category->id,
+        'name' => 'Updated Category Name',
+    ]);
+});
+
+it('validates category update fields', function () {
+    $category = Category::factory()->create();
+
+    $this->put(route('categories.update', $category), ['name' => ''])
+        ->assertSessionHasErrors(['name']);
+});
+
+it('can update a category with a new parent', function () {
+    $parentCategory = Category::factory()->create(['name' => 'Parent Category']);
+    $category = Category::factory()->create(['name' => 'Child Category']);
+
+    $updatedData = [
+        'name' => 'Updated Child Category',
+        'parent_id' => $parentCategory->id,
+    ];
+
+    $this->put(route('categories.update', $category), $updatedData)
+        ->assertRedirect(route('categories.index'))
+        ->assertSessionHas('success', 'Category updated successfully.');
+
+    $this->assertDatabaseHas('categories', [
+        'id' => $category->id,
+        'name' => 'Updated Child Category',
+        'parent_id' => $parentCategory->id,
+    ]);
+});

--- a/tests/Feature/Category/CategoryIndexTest.php
+++ b/tests/Feature/Category/CategoryIndexTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(); // Assuming you have a seed that creates necessary data like users or categories
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    Category::factory()->count(5)->create();
+});
+
+it('can display the category index page', function () {
+    $category = Category::factory()->create([
+        'name' => 'Sample Category',
+    ]);
+
+    $this->get(route('categories.index'))
+        ->assertStatus(200)
+        ->assertSee('Categories')
+        ->assertSee('Sample Category')
+        ->assertViewIs('category.index');
+});
+
+it('shows no categories available when there are none', function () {
+    Category::query()->delete();
+
+    $this->get(route('categories.index'))
+        ->assertStatus(200)
+        ->assertSee('No categories available');
+});
+
+it('has a create new category button', function () {
+    $this->get(route('categories.index'))
+        ->assertStatus(200)
+        ->assertSee('Create New Category')
+        ->assertSee(route('categories.create'));
+});
+
+it('displays pagination links when categories exceed the page limit', function () {
+    Category::factory()->count(15)->create();
+
+    $this->get(route('categories.index'))
+        ->assertStatus(200)
+        ->assertSee('Next')
+        ->assertSee('Previous');
+});


### PR DESCRIPTION
This Pull Request introduces feature tests for the category deletion functionality, ensuring robust handling of category removal in different scenarios:

### Tests Added:
1. **Delete Category without Posts**:
   - Added a test to verify that a category can be deleted successfully if it is not associated with any posts.
   - Ensures that the category is removed from the database and a success message is returned.

2. **Prevent Deletion of Category with Posts**:
   - Added a test to confirm that categories associated with existing posts cannot be deleted.
   - Ensures that the appropriate error message is displayed, and the category remains in the database.

### Purpose:
- Enhance reliability by testing edge cases where categories are tied to posts, ensuring that critical data isn't unintentionally deleted.
- Provides a solid foundation for category management features, making the application more user-friendly and error-resilient.

Please review these tests to ensure they align with our intended use cases and quality standards. Let me know if any adjustments are required.

close #3 
